### PR TITLE
Dedicated OTP form

### DIFF
--- a/XIVLauncher/App.config
+++ b/XIVLauncher/App.config
@@ -17,16 +17,16 @@
                 <value>False</value>
             </setting>
             <setting name="gamepath" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="language" serializeAs="String">
                 <value>1</value>
             </setting>
             <setting name="savedid" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="savedpw" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="autologin" serializeAs="String">
                 <value>False</value>
@@ -36,6 +36,9 @@
             </setting>
             <setting name="expansionlevel" serializeAs="String">
                 <value>0</value>
+            </setting>
+            <setting name="otprequired" serializeAs="String">
+                <value>False</value>
             </setting>
         </XIVLauncher.Properties.Settings>
     </userSettings>

--- a/XIVLauncher/MainForm.Designer.cs
+++ b/XIVLauncher/MainForm.Designer.cs
@@ -36,11 +36,10 @@
             this.autoLoginCheckBox = new System.Windows.Forms.CheckBox();
             this.IDLabel = new System.Windows.Forms.Label();
             this.PWLabel = new System.Windows.Forms.Label();
-            this.OTPLabel = new System.Windows.Forms.Label();
-            this.OTPTextBox = new System.Windows.Forms.TextBox();
             this.StatusLabel = new System.Windows.Forms.Label();
             this.GamePathDialog = new System.Windows.Forms.FolderBrowserDialog();
             this.QueueButton = new System.Windows.Forms.Button();
+            this.otpCheckBox = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // IDTextBox
@@ -120,24 +119,6 @@
             this.PWLabel.TabIndex = 7;
             this.PWLabel.Text = "Password";
             // 
-            // OTPLabel
-            // 
-            this.OTPLabel.AutoSize = true;
-            this.OTPLabel.Location = new System.Drawing.Point(12, 89);
-            this.OTPLabel.Name = "OTPLabel";
-            this.OTPLabel.Size = new System.Drawing.Size(29, 13);
-            this.OTPLabel.TabIndex = 9;
-            this.OTPLabel.Text = "OTP";
-            // 
-            // OTPTextBox
-            // 
-            this.OTPTextBox.Location = new System.Drawing.Point(99, 87);
-            this.OTPTextBox.MaxLength = 6;
-            this.OTPTextBox.Name = "OTPTextBox";
-            this.OTPTextBox.Size = new System.Drawing.Size(129, 20);
-            this.OTPTextBox.TabIndex = 2;
-            this.OTPTextBox.UseSystemPasswordChar = true;
-            // 
             // StatusLabel
             // 
             this.StatusLabel.AutoSize = true;
@@ -163,16 +144,25 @@
             this.QueueButton.UseVisualStyleBackColor = true;
             this.QueueButton.Click += new System.EventHandler(this.QueueButton_Click);
             // 
+            // otpCheckBox
+            // 
+            this.otpCheckBox.AutoSize = true;
+            this.otpCheckBox.Location = new System.Drawing.Point(40, 96);
+            this.otpCheckBox.Name = "otpCheckBox";
+            this.otpCheckBox.Size = new System.Drawing.Size(139, 17);
+            this.otpCheckBox.TabIndex = 12;
+            this.otpCheckBox.Text = "use one-time passwords";
+            this.otpCheckBox.UseVisualStyleBackColor = true;
+            // 
             // MainForm
             // 
             this.AcceptButton = this.loginButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(243, 272);
+            this.Controls.Add(this.otpCheckBox);
             this.Controls.Add(this.QueueButton);
             this.Controls.Add(this.StatusLabel);
-            this.Controls.Add(this.OTPLabel);
-            this.Controls.Add(this.OTPTextBox);
             this.Controls.Add(this.PWLabel);
             this.Controls.Add(this.IDLabel);
             this.Controls.Add(this.autoLoginCheckBox);
@@ -200,11 +190,10 @@
         private System.Windows.Forms.CheckBox autoLoginCheckBox;
         private System.Windows.Forms.Label IDLabel;
         private System.Windows.Forms.Label PWLabel;
-        private System.Windows.Forms.Label OTPLabel;
-        private System.Windows.Forms.TextBox OTPTextBox;
         private System.Windows.Forms.Label StatusLabel;
         private System.Windows.Forms.FolderBrowserDialog GamePathDialog;
         private System.Windows.Forms.Button QueueButton;
+        private System.Windows.Forms.CheckBox otpCheckBox;
     }
 }
 

--- a/XIVLauncher/MainForm.cs
+++ b/XIVLauncher/MainForm.cs
@@ -14,6 +14,7 @@ namespace XIVLauncher
             {
                 IDTextBox.Text = Properties.Settings.Default.savedid;
                 PWTextBox.Text = Properties.Settings.Default.savedpw;
+                otpCheckBox.Checked = Properties.Settings.Default.otprequired;
                 saveCheckBox.Checked = true;
             }
 
@@ -39,7 +40,7 @@ namespace XIVLauncher
                     }
                     else
                     {
-                        XIVGame.Login(IDTextBox.Text, PWTextBox.Text, OTPTextBox.Text);
+                        XIVGame.Login(IDTextBox.Text, PWTextBox.Text, "");
                         Environment.Exit(0);
                     }
                 }
@@ -78,6 +79,8 @@ namespace XIVLauncher
             {
                 Properties.Settings.Default["savedid"] = IDTextBox.Text;
                 Properties.Settings.Default["savedpw"] = PWTextBox.Text;
+                Properties.Settings.Default.otprequired = otpCheckBox.Checked;
+
                 if (autoLoginCheckBox.Checked)
                 {
                     DialogResult result = MessageBox.Show("This option will log you in automatically with the credentials you entered.\nTo reset it again, launch this application as administrator once.\n\nDo you really want to enable it?", "Enabling Autologin", MessageBoxButtons.YesNo);
@@ -100,11 +103,24 @@ namespace XIVLauncher
                 Properties.Settings.Default["savedpw"] = "";
                 Properties.Settings.Default.Save();
             }
+            if (otpCheckBox.Checked)
+            {
+                OTPForm otpForm = new OTPForm();
+                otpForm.ShowDialog();
+                if (otpForm.Success)
+                {
+                    Close();
+                }
+                else
+                {
+                    return;
+                }
+            }
 
             StatusLabel.Text = "Logging in...";
             try
             {
-                XIVGame.Login(IDTextBox.Text, PWTextBox.Text, OTPTextBox.Text);
+                XIVGame.Login(IDTextBox.Text, PWTextBox.Text, "");
                 Environment.Exit(0);
             }
             catch(Exception exc)

--- a/XIVLauncher/OTPForm.Designer.cs
+++ b/XIVLauncher/OTPForm.Designer.cs
@@ -1,0 +1,63 @@
+﻿namespace XIVLauncher
+{
+    partial class OTPForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.otpField = new System.Windows.Forms.TextBox();
+            this.SuspendLayout();
+            // 
+            // otpField
+            // 
+            this.otpField.Font = new System.Drawing.Font("Courier New", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.otpField.Location = new System.Drawing.Point(13, 13);
+            this.otpField.Name = "otpField";
+            this.otpField.Size = new System.Drawing.Size(259, 31);
+            this.otpField.TabIndex = 0;
+            // 
+            // OTPForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(284, 58);
+            this.Controls.Add(this.otpField);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "OTPForm";
+            this.ShowIcon = false;
+            this.Text = "One-Time Password";
+            this.Load += new System.EventHandler(this.OTPForm_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox otpField;
+    }
+}

--- a/XIVLauncher/OTPForm.cs
+++ b/XIVLauncher/OTPForm.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace XIVLauncher
+{
+    public partial class OTPForm : Form
+    {
+        public bool Success { get; set; }
+
+        public OTPForm()
+        {
+            InitializeComponent();
+            Success = false;
+        }
+
+        private void OTPForm_Load(object sender, EventArgs e)
+        {
+            this.otpField.KeyPress += new System.Windows.Forms.KeyPressEventHandler(OTPFieldEnterKeyPress);
+        }
+
+        private void OTPFieldEnterKeyPress(object sender, System.Windows.Forms.KeyPressEventArgs e)
+        {
+            if (e.KeyChar == (char)Keys.Return)
+            {
+                try
+                {
+                    XIVGame.Login(Properties.Settings.Default.savedid, Properties.Settings.Default.savedpw, otpField.Text);
+                    Success = true;
+                    Close();
+                }
+                catch (Exception ex)
+                {
+                    Success = false;
+                    MessageBox.Show("Logging in failed, check your login information or try again.\n\n" + e, "Login failed", MessageBoxButtons.OK);
+                    Properties.Settings.Default.autologin = false;
+                    Close();
+                }
+            }
+        }
+    }
+}

--- a/XIVLauncher/OTPForm.resx
+++ b/XIVLauncher/OTPForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/XIVLauncher/Program.cs
+++ b/XIVLauncher/Program.cs
@@ -13,6 +13,18 @@ namespace XIVLauncher
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+            if (Properties.Settings.Default.setupcomplete == true && Properties.Settings.Default.autologin == true && !Settings.IsAdministrator() && Properties.Settings.Default.otprequired == true)
+            {
+                OTPForm form = new OTPForm();
+                Application.Run(form);
+                if (form.Success)
+                {
+                    return;
+                } else
+                {
+                    Properties.Settings.Default.autologin = false;
+                }
+            }
             Application.Run(new MainForm());
         }
     }

--- a/XIVLauncher/Properties/Settings.Designer.cs
+++ b/XIVLauncher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace XIVLauncher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -116,6 +116,18 @@ namespace XIVLauncher.Properties {
             }
             set {
                 this["expansionlevel"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool otprequired {
+            get {
+                return ((bool)(this["otprequired"]));
+            }
+            set {
+                this["otprequired"] = value;
             }
         }
     }

--- a/XIVLauncher/Properties/Settings.settings
+++ b/XIVLauncher/Properties/Settings.settings
@@ -26,5 +26,8 @@
     <Setting Name="expansionlevel" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="otprequired" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/XIVLauncher/XIVLauncher.csproj
+++ b/XIVLauncher/XIVLauncher.csproj
@@ -74,6 +74,12 @@
     <Compile Include="OptionsForm.Designer.cs">
       <DependentUpon>OptionsForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="OTPForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="OTPForm.Designer.cs">
+      <DependentUpon>OTPForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Reflector.cs" />
@@ -87,6 +93,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="OptionsForm.resx">
       <DependentUpon>OptionsForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="OTPForm.resx">
+      <DependentUpon>OTPForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>


### PR DESCRIPTION
Modifies the One-Time Password logic to better suit "autologin" behaviour.

Use of One-Time Passwords is now a checkbox in the main form, rather than a field...
![2019-01-12 23_42_58-xiv launcher](https://user-images.githubusercontent.com/819705/51073366-e9e45580-16c3-11e9-8027-86fc179e5bfa.jpg)

...because One-Time Passwords are now presented in their own form:
![2019-01-12 23_46_00-one-time password](https://user-images.githubusercontent.com/819705/51073383-3e87d080-16c4-11e9-957a-0476d282a2a7.jpg)

If you enable save + autologin, you will now get the above OTP form instead of the main form. If you close that form, or if login fails, you'll be returned to the main form.

## Rationale

When using One-Time Passwords, you still want FFXIVQuickLauncher to remember your ID and Password, the only field required for each launch is your OTP. Current behaviour is, trying to enable save + autologin with an account with OTPs will always result in a login error on subsequent launch.

This approach allows us to "support" autologins, in a fashion, for accounts with OTP enabled.

The happy path should be: 

1. double click the launcher
2. get OTP prompt
3. enter from smartphone / token
4. press enter
5. game opens

On the other hand, for users with OTP that don't use save + autologin, it means OTP has to be entered in a new window, which is slightly less convenient. I would argue this change is still worthwhile, since anyone concerned with convenience should probably just enable autologin.