### PR TITLE
Add working directory to run addon

### DIFF
--- a/XIVLauncher/Addon/GenericAddon.cs
+++ b/XIVLauncher/Addon/GenericAddon.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -15,7 +15,15 @@ namespace XIVLauncher.Addon
             if (Process.GetProcessesByName(System.IO.Path.GetFileNameWithoutExtension(Path)).Any())
                 return;
 
-            var process = new Process {StartInfo = {FileName = Path, Arguments = CommandLine}};
+            var process = new Process
+            {
+                StartInfo =
+                {
+                    FileName = Path,
+                    Arguments = CommandLine,
+                    WorkingDirectory = System.IO.Path.GetDirectoryName(Path),
+                }
+            };
 
             if (RunAsAdmin)
             {


### PR DESCRIPTION
I added "Advanced Combat Tracker" as an add-on.
However, ACT has been launched in the QuickLauncher working directory.

Added WorkingDirectory to ProcessStartInfo for addon.