### PR TITLE
Fix crashes when no game path is set

### DIFF
--- a/XIVLauncher/Settings.cs
+++ b/XIVLauncher/Settings.cs
@@ -26,7 +26,7 @@ namespace XIVLauncher
 
                 return new DirectoryInfo(Properties.Settings.Default.GamePath);
             }
-            set => Properties.Settings.Default.GamePath = value.FullName;
+            set => Properties.Settings.Default.GamePath = value?.FullName;
         }
 
         public static ClientLanguage GetLanguage()

--- a/XIVLauncher/Windows/SettingsWindow.xaml
+++ b/XIVLauncher/Windows/SettingsWindow.xaml
@@ -9,13 +9,16 @@
         xmlns:dalamudDiscord="clr-namespace:Dalamud.Discord"
         xmlns:xaml="clr-namespace:XIVLauncher.Xaml"
         xmlns:components="clr-namespace:XIVLauncher.Xaml.Components"
+        xmlns:properties="clr-namespace:XIVLauncher.Properties"
+        xmlns:windows="clr-namespace:XIVLauncher.Windows"
         mc:Ignorable="d"
         Title="XIVLauncher Settings" Height="311.675" Width="567" WindowStartupLocation="CenterScreen"
         Icon="pack://application:,,,/Resources/dalamud_icon.ico" ResizeMode="NoResize" Closing="SettingsWindow_OnClosing"
         TextElement.Foreground="{DynamicResource MaterialDesignBody}"
         Background="{DynamicResource MaterialDesignPaper}"
         TextElement.FontWeight="Medium"
-        FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto">
+        FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto"
+        d:DataContext="{d:DesignInstance windows:SettingsWindow}">
     <Window.Resources>
         <xaml:StringToColorConverter x:Uid="xaml:StringToColorConverter_1" x:Key="StringToColorConverter"/>
         <xaml:ChatTypeToFancyNameConverter x:Uid="xaml:ChatTypeToFancyNameConverter_1" x:Key="ChatTypeToFancyNameConverter"/>
@@ -29,11 +32,11 @@
                         <LineBreak x:Uid="LineBreak_1"/>
                         It should contain the folders "game" and "boot".
                     </TextBlock>
-                    <components:FolderEntry x:Uid="GamePathEntry" x:Name="GamePathEntry" Description="Select a folder" Width="400" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource MaterialDesignBody}" Margin="0,5,0,0"/>
+                    <components:FolderEntry x:Uid="GamePathEntry" x:Name="GamePathEntry" Text="{Binding GamePath, UpdateSourceTrigger=PropertyChanged}" Description="Select a folder" Width="400" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource MaterialDesignBody}" Margin="0,5,0,0"/>
                     <CheckBox x:Uid="SteamIntegrationCheckBox" Foreground="{DynamicResource MaterialDesignBody}" x:Name="SteamIntegrationCheckBox" Margin="0,15,0,0">Enable Steam integration</CheckBox>
                     <Label x:Uid="Label_1" Margin="0,10,0,0">Additional launch arguments</Label>
                     <TextBox x:Uid="LaunchArgsTextBox" Width="400" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource MaterialDesignBody}" Margin="0,5,0,0" x:Name="LaunchArgsTextBox"/>
-                    <Button x:Uid="Button_1" HorizontalAlignment="Left" Click="RunIntegrityCheck_OnClick" ToolTip="Run integrity check on game files." Margin="10,20,0,0">Run integrity check</Button>
+                    <Button x:Uid="Button_1" HorizontalAlignment="Left" Click="RunIntegrityCheck_OnClick" IsEnabled="{Binding IsRunIntegrityCheckPossible}" ToolTip="Run integrity check on game files." Margin="10,20,0,0">Run integrity check</Button>
                 </StackPanel>
             </TabItem>
             <TabItem x:Uid="TabItem_2" Header="DirectX">

--- a/XIVLauncher/Xaml/Components/FolderEntry.xaml
+++ b/XIVLauncher/Xaml/Components/FolderEntry.xaml
@@ -4,6 +4,6 @@
     <DockPanel x:Uid="DockPanel_1">
         <Button x:Uid="Button_1" Margin="5,0,0,0" Padding="0" DockPanel.Dock="Right" Width="35" Click="BrowseFolder">...</Button>
         <TextBox x:Uid="TextBox_1" Height="Auto" HorizontalAlignment="Stretch" DockPanel.Dock="Right" 
-                 Text="{Binding Text, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}" />
+                 Text="{Binding Text, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, UpdateSourceTrigger=PropertyChanged}" />
     </DockPanel>
 </UserControl>

--- a/XIVLauncher/Xaml/Components/FolderEntry.xaml.cs
+++ b/XIVLauncher/Xaml/Components/FolderEntry.xaml.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows;
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Controls;
 using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace XIVLauncher.Xaml.Components


### PR DESCRIPTION
Fixes #95, and makes the settings missing a game path more robust.

Edit: I wouldn't mind doing some more issues and refactoring if it's okay for you.