### PR TITLE
prevent login if malformed otp received

### DIFF
--- a/XIVLauncher/Http/OtpListener.cs
+++ b/XIVLauncher/Http/OtpListener.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using System.Windows;
 
 namespace XIVLauncher.Http
 {
@@ -27,6 +28,12 @@ namespace XIVLauncher.Http
             if (e.Path.StartsWith("/ffxivlauncher/"))
             {
                 var otp = e.Path.Substring(15);
+                if (otp.Length < 6)
+                {
+                    MessageBox.Show("Received malformed OTP code, please check macro.",
+                        "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
 
                 OnOtpReceived?.Invoke(otp);
             }


### PR DESCRIPTION
This should help solve #132 so that we don't try to login without a correct OTP