### PR TITLE
Fix issue #136

### DIFF
--- a/XIVLauncher/Accounts/AccountManager.cs
+++ b/XIVLauncher/Accounts/AccountManager.cs
@@ -14,7 +14,9 @@ namespace XIVLauncher.Accounts
         public ObservableCollection<XivAccount> Accounts;
 
         public XivAccount CurrentAccount =>
-            Accounts.FirstOrDefault(a => a.Id == Properties.Settings.Default.CurrentAccount);
+            Accounts.Count > 1 ? 
+                Accounts.FirstOrDefault(a => a.Id == Properties.Settings.Default.CurrentAccount) :
+                Accounts.FirstOrDefault();
 
         public AccountManager()
         {


### PR DESCRIPTION
The issue was caused because no default account was setup in the settings. So i changed the account manager to load the first account in the account list only if the account list has just one item.