### PR TITLE
Bugfix: Don't block other addons when loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# XL Debug dirs
+XIVLauncher/XIVLauncher/app-*

--- a/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -386,20 +386,26 @@ namespace XIVLauncher.Windows
                 try
                 {
                     var addons = _setting.AddonList.Where(x => x.IsEnabled).ToList();
+                    try
+                    {
+                        var backupDirectory = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "XIVLauncher", "charDataBackup"));
+                        if (backupDirectory.Exists)
+                            backupDirectory.Delete(true);
 
-                    addons.Add(new AddonEntry{
+                        addons.Add(new AddonEntry
+                        {
                             Addon = new CharacterBackupAddon()
                         });
+                    }
+                    catch (Exception ex)
+                    {
+                        new ErrorWindow(ex, "Could not delete backup directory to start character backup Addon. This addon will be skipped", "Addons").ShowDialog();
+                    }
 
                     if (_setting.CharacterSyncEnabled)
                         addons.Add(new AddonEntry{
                             Addon = new CharacterSyncAddon()
                         });
-
-                    var backupDirectory = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "XIVLauncher", "charDataBackup"));
-
-                    if (backupDirectory.Exists)
-                        backupDirectory.Delete(true);
 
                     await Task.Run(() => addonMgr.RunAddons(gameProcess, _setting, addons));
                 }


### PR DESCRIPTION
This is related to #138 not sure if this is the solution that we'd go for, but this would help prevent crashing the entire addon loading process by simply skipping the charbackup addon if it fails in regards to deleting existing directories